### PR TITLE
feat(cli): add per-inference timings and headless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `--timings_csv <path>` writes one row per inference (`frame,latency_us`) for
+  a video run. The run report carries per-stage totals and throughput but not
+  the distribution, so a run whose mean is fine because one slow frame was
+  averaged away by four hundred quick ones is indistinguishable from a
+  uniformly quick one. The file is opened before the first frame, so a run that
+  cannot write its measurements fails before spending minutes producing them,
+  and parent directories are created.
+- `--no_display` suppresses the preview window. This is not only a convenience:
+  with no `DISPLAY`, `cv::imshow` aborts the process on its Qt platform plugin,
+  so before this flag a headless or benchmark run could not complete at all.
+  Verified on a 404-frame 1280x720 clip through the ONNX Runtime backend --
+  404 rows written and the run finished, where the same command without the
+  flag dumps core.
 - Machine-readable run diagnostics. Every run now writes a versioned report
   (`data/output/run_report.json`, advertised by `--capabilities` under
   `diagnostics.run_report`) carrying per-stage timings, sample/frame counts,
@@ -54,6 +67,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   may reference a different inner version.
 
 ### Fixed
+- Video FPS overlay no longer divides by zero. It measured in whole
+  milliseconds, so any inference faster than 1 ms truncated to zero and the
+  overlay reported `inf` -- on exactly the fast backends worth measuring. The
+  measurement is now in microseconds.
 - Polygon segmentation rendering filled the exteriors and alpha-blended them,
   which is visually indistinguishable from the mask overlay and never drew the
   perimeter. Polygon results now stroke closed outline contours only

--- a/app/inc/AppConfig.hpp
+++ b/app/inc/AppConfig.hpp
@@ -58,4 +58,11 @@ struct AppConfig {
   // may reference an inner model version other than the ensemble's own.
   std::string task_model_version{"1"};
   std::string postprocess_mode{"cpu"};
+  // Video run artifacts. timings_csv records per-inference latency so two
+  // transport or backend configurations can be compared without re-running
+  // them; the run report covers per-stage totals but not the frame-by-frame
+  // distribution. no_display suppresses the preview window, which a headless
+  // or benchmark run neither needs nor can open.
+  std::string timings_csv;
+  bool no_display{false};
 };

--- a/app/src/CLICommands.cpp
+++ b/app/src/CLICommands.cpp
@@ -8,6 +8,7 @@
 
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -306,6 +307,51 @@ void processImage(InferencePipeline &pipeline, const std::string &source) {
   }
 }
 
+// Per-inference latency, one row per inference, opened only when asked for.
+// The run report already carries per-stage totals and throughput; what it
+// cannot show is the distribution -- a run whose mean is fine because a slow
+// first frame is averaged away by four hundred quick ones looks identical to a
+// uniformly quick run. That distinction is the reason to record frames
+// individually, so this writes alongside the report rather than duplicating it.
+class FrameTimingsCsv {
+public:
+  // Opened before the first frame, not lazily: a run that cannot write its
+  // measurements should fail before spending minutes producing them.
+  explicit FrameTimingsCsv(const std::string &path) {
+    if (path.empty()) {
+      return;
+    }
+    const std::filesystem::path csv_path(path);
+    if (csv_path.has_parent_path()) {
+      std::filesystem::create_directories(csv_path.parent_path());
+    }
+    out_.open(csv_path);
+    if (!out_.is_open()) {
+      throw std::runtime_error("Could not open timings CSV for writing: " +
+                               path);
+    }
+    path_ = path;
+    out_ << "frame,latency_us\n";
+  }
+
+  void add(std::size_t frame_index, std::int64_t latency_us) {
+    if (out_.is_open()) {
+      out_ << frame_index << ',' << latency_us << '\n';
+    }
+  }
+
+  void finish() {
+    if (out_.is_open()) {
+      out_.close();
+      LOG(INFO) << "Saved per-inference timings to: " << path_;
+    }
+  }
+
+private:
+  std::ofstream out_;
+  std::string path_;
+};
+
 void processVideo(InferencePipeline &pipeline, const std::string &source) {
   std::unique_ptr<VideoCaptureInterface> videoInterface =
       createVideoInterface();
@@ -318,7 +364,10 @@ void processVideo(InferencePipeline &pipeline, const std::string &source) {
     }
   }
 
+  FrameTimingsCsv timings(pipeline.config.timings_csv);
+
   cv::Mat frame;
+  std::size_t frame_index = 0;
   bool read_to_end = false;
   while (true) {
     bool read_frame = false;
@@ -341,10 +390,15 @@ void processVideo(InferencePipeline &pipeline, const std::string &source) {
       pipeline.report->addFrames(1);
     }
     auto end = std::chrono::steady_clock::now();
-    auto duration =
-        std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+    // Microseconds, not milliseconds: a frame faster than 1 ms truncated to
+    // zero, and the overlay then divided by it -- inf FPS on exactly the
+    // backends worth measuring.
+    const auto latency_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(end - start)
             .count();
-    double fps = 1000.0 / static_cast<double>(duration);
+    timings.add(frame_index, latency_us);
+    const double fps =
+        latency_us > 0 ? 1e6 / static_cast<double>(latency_us) : 0.0;
     std::string fpsText = "FPS: " + std::to_string(fps);
 
     {
@@ -355,16 +409,25 @@ void processVideo(InferencePipeline &pipeline, const std::string &source) {
       cv::putText(frame, fpsText, cv::Point(10, 30), cv::FONT_HERSHEY_SIMPLEX,
                   1, cv::Scalar(0, 255, 0), 2);
       pipeline.renderResults(results, frame);
-      cv::imshow("opencv feed", frame);
+      if (!pipeline.config.no_display) {
+        cv::imshow("opencv feed", frame);
+      }
     }
 
-    const int key = cv::waitKey(1);
-    if (key == 27 || key == 'q') {
-      LOG(INFO) << "Exit requested";
-      break;
+    ++frame_index;
+
+    // Only a shown window can be asked to close. Without one there is no
+    // keypress to read, and cv::waitKey would spin the loop for nothing.
+    if (!pipeline.config.no_display) {
+      const int key = cv::waitKey(1);
+      if (key == 27 || key == 'q') {
+        LOG(INFO) << "Exit requested";
+        break;
+      }
     }
   }
 
+  timings.finish();
   videoInterface->release();
   // One video read to its end is one sample, however many frames it held. A
   // video the operator stopped early was not processed to completion, and
@@ -391,10 +454,17 @@ void processVideoClassification(InferencePipeline &pipeline,
   LOG(INFO) << "Video classification mode: accumulating " << requiredFrames
             << " frames";
 
+  FrameTimingsCsv timings(pipeline.config.timings_csv);
+
   cv::Mat frame;
   std::vector<cv::Mat> frameBuffer;
   frameBuffer.reserve(static_cast<size_t>(requiredFrames));
 
+  // Counts frames read, so a row's index refers to the frame the window closed
+  // on. One inference here consumes a whole window, so rows are sparser than in
+  // processVideo -- which is why the column is the frame index and not a row
+  // counter that would silently mean something different per mode.
+  std::size_t frame_index = 0;
   bool read_to_end = false;
   while (true) {
     bool read_frame = false;
@@ -408,6 +478,7 @@ void processVideoClassification(InferencePipeline &pipeline,
       break;
     }
     frameBuffer.push_back(frame.clone());
+    ++frame_index;
 
     if (static_cast<int>(frameBuffer.size()) >= requiredFrames) {
       auto start = std::chrono::steady_clock::now();
@@ -434,10 +505,12 @@ void processVideoClassification(InferencePipeline &pipeline,
         pipeline.report->addFrames(requiredFrames);
       }
       auto end = std::chrono::steady_clock::now();
-      auto duration =
-          std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+      const auto latency_us =
+          std::chrono::duration_cast<std::chrono::microseconds>(end - start)
               .count();
-      double fps = 1000.0 / static_cast<double>(duration);
+      timings.add(frame_index - 1, latency_us);
+      const double fps =
+          latency_us > 0 ? 1e6 / static_cast<double>(latency_us) : 0.0;
       std::string fpsText = "FPS: " + std::to_string(fps);
 
       {
@@ -448,19 +521,24 @@ void processVideoClassification(InferencePipeline &pipeline,
                     cv::FONT_HERSHEY_SIMPLEX, 1, cv::Scalar(0, 255, 0), 2);
 
         pipeline.renderResults(results, displayFrame);
-        cv::imshow("opencv feed", displayFrame);
+        if (!pipeline.config.no_display) {
+          cv::imshow("opencv feed", displayFrame);
+        }
       }
 
       frameBuffer.erase(frameBuffer.begin());
     }
 
-    const int key = cv::waitKey(1);
-    if (key == 27 || key == 'q') {
-      LOG(INFO) << "Exit requested";
-      break;
+    if (!pipeline.config.no_display) {
+      const int key = cv::waitKey(1);
+      if (key == 27 || key == 'q') {
+        LOG(INFO) << "Exit requested";
+        break;
+      }
     }
   }
 
+  timings.finish();
   videoInterface->release();
   // Same rule as processVideo: only a video read to its end is a sample.
   if (read_to_end && pipeline.report != nullptr) {

--- a/app/src/CommandLineParser.cpp
+++ b/app/src/CommandLineParser.cpp
@@ -63,7 +63,10 @@ const std::string CommandLineParser::params =
     "{ task_model tm | | inner model used for task metadata in encoded-image "
     "mode }"
     "{ postprocess_mode pm | cpu | postprocessing placement: cpu or gpu }"
-    "{ task_model_version tmv | 1 | version of --task_model }";
+    "{ task_model_version tmv | 1 | version of --task_model }"
+    "{ timings_csv | | write per-inference latency measurements to this CSV "
+    "path }"
+    "{ no_display | false | do not open the preview window }";
 
 namespace {
 
@@ -257,6 +260,9 @@ AppConfig CommandLineParser::parseCommandLineArguments(int argc, char *argv[]) {
                  config.postprocess_mode.begin(), [](unsigned char c) {
                    return static_cast<char>(std::tolower(c));
                  });
+
+  config.timings_csv = parser.get<std::string>("timings_csv");
+  config.no_display = parser.get<bool>("no_display");
 
   if (!config.kserve_endpoint.empty() && config.kserve_model_name.empty()) {
     config.kserve_model_name = config.detectorType;

--- a/app/test/test_parseCommandLineArguments.cpp
+++ b/app/test/test_parseCommandLineArguments.cpp
@@ -341,3 +341,38 @@ TEST(ParseCommandLineArguments, TaskModelVersionDefaultsAndParses) {
   EXPECT_EQ(config.kserve_model_version, "3");
   EXPECT_EQ(config.task_model_version, "7");
 }
+
+TEST(ParseCommandLineArguments, VideoRunArtifactFlagsDefaultToOff) {
+  // A run that asks for neither must behave exactly as before: no CSV path and
+  // a preview window, since --no_display is opt-in.
+  const char *argv[] = {"program", "--type=yolov5", "--source=input.mp4",
+                        "--weights=model.weights", "--labels=labels.txt"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  touchFile("input.mp4");
+  touchFile("model.weights");
+  touchFile("labels.txt");
+  AppConfig config = CommandLineParser::parseCommandLineArguments(
+      argc, const_cast<char **>(argv));
+
+  EXPECT_TRUE(config.timings_csv.empty());
+  EXPECT_FALSE(config.no_display);
+}
+
+TEST(ParseCommandLineArguments, VideoRunArtifactFlagsAreParsed) {
+  const char *argv[] = {"program",
+                        "--type=yolov5",
+                        "--source=input.mp4",
+                        "--weights=model.weights",
+                        "--labels=labels.txt",
+                        "--timings_csv=out/frames.csv",
+                        "--no_display"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  touchFile("input.mp4");
+  touchFile("model.weights");
+  touchFile("labels.txt");
+  AppConfig config = CommandLineParser::parseCommandLineArguments(
+      argc, const_cast<char **>(argv));
+
+  EXPECT_EQ(config.timings_csv, "out/frames.csv");
+  EXPECT_TRUE(config.no_display);
+}


### PR DESCRIPTION
## Summary

- add `--timings_csv` for one row per inference in both video paths
- add `--no_display` so video inference can complete in headless environments
- measure latency in microseconds to avoid zero-duration FPS calculations
- retain frame indices for classification-window timing rows

## Validation

- `cmake --build build-test --parallel 8`
- `ctest --test-dir build-test --output-on-failure` — 75/75 passed
- `clang-format-18 --dry-run --Werror` on all changed C++ files
- `python3 scripts/sync_supported_model_types.py --check --neuriplo-tasks-readme /home/oli/repos/neuriplo-tasks/README.md`
- `git diff --check origin/develop...HEAD`

## Runtime evidence

Previously verified on a 404-frame 1280x720 video through ONNX Runtime: `--no_display` completed and emitted 404 timing rows; without it, Qt-backed `cv::imshow` aborted when `DISPLAY` was unset.