### PR TITLE
feat(videocapture): adopt v0.4.0 Frame API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   what the local postprocessor produces.
 
 ### Changed
+- Pinned `videocapture` to `v0.4.0` (was `v0.3.0`), a breaking release for
+  consumers: `VideoCaptureInterface::readFrame()` now fills a
+  `videocapture::Frame` instead of a `cv::Mat`. `Frame` is dependency-free and
+  carries an explicit pixel format, per-plane row strides, a presentation
+  timestamp, and a sequence number. Video capture also no longer hangs at end
+  of stream on the GStreamer backend, and `GStreamerOpenCV` was renamed to
+  `GStreamerPipeline`.
+  - Frames are bridged to OpenCV in one place, `neuriplo_infer::toBgrMat()`
+    (`app/inc/FrameConversion.hpp`), rather than teaching every pipeline stage
+    a second image type. For packed BGR8 -- what all three capture backends
+    produce today -- the returned `cv::Mat` aliases the frame's own storage, so
+    the common path copies nothing and the rendered overlay still lands in the
+    frame's buffer. Other formats, including planar NV12 and YUV420P, are
+    converted; a 4:2:0 frame whose layout is not the canonical packed one is
+    rejected rather than reinterpreted.
+  - The app no longer injects OpenCV into the fetched `VideoCapture` target.
+    Up to v0.3.0 that was required, because `cv::Mat` was in the library's
+    public API; since v0.4.0 OpenCV is internal to its OpenCV capture backend,
+    which finds and links it itself. Keeping the injection would have put
+    OpenCV back into the FFmpeg and GStreamer builds that release exists to
+    free of it.
 - **Breaking:** the capabilities document is now `schema_version` 2. It gained
   the required `diagnostics` section, and because the schema forbids unknown
   properties that is breaking in both directions; version 1 is preserved as

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,11 +219,12 @@ message(STATUS "neuriplo-tasks_SOURCE_DIR: ${neuriplo-tasks_SOURCE_DIR}")
 message(STATUS "neuriplo_SOURCE_DIR: ${neuriplo_SOURCE_DIR}")
 message(STATUS "VideoCapture_SOURCE_DIR: ${VideoCapture_SOURCE_DIR}")
 
-# Configure VideoCapture target with OpenCV after it's been fetched
-if(TARGET VideoCapture)
-    target_include_directories(VideoCapture PRIVATE ${OpenCV_INCLUDE_DIRS})
-    target_link_libraries(VideoCapture PRIVATE ${OpenCV_LIBS})
-endif()
+# VideoCapture is deliberately not given OpenCV here. Up to v0.3.0 it expected
+# its consumer to supply OpenCV, because cv::Mat was in its public frame API.
+# Since v0.4.0 the frame API is videocapture::Frame and OpenCV is an internal
+# detail of the OpenCV capture backend alone -- which discovers and links it
+# itself. Injecting OpenCV into the target from here would put it back into the
+# FFmpeg and GStreamer builds, which that release exists to keep free of it.
 
 # Validate all dependencies after they have been fetched
 validate_project_dependencies()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -4,6 +4,7 @@ set(APP_LIB_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/NeuriploInfer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/InferencePipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CLICommands.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/FrameConversion.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ResultRenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/NeuriploInferTaskRouting.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/utils.cpp

--- a/app/inc/FrameConversion.hpp
+++ b/app/inc/FrameConversion.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Frame.hpp"
+
+#include <opencv2/core.hpp>
+
+namespace neuriplo_infer {
+
+// videocapture v0.4.0 moved VideoCaptureInterface::readFrame() off cv::Mat and
+// onto videocapture::Frame, a dependency-free carrier with an explicit pixel
+// format, per-plane row strides, and a timestamp. The app pipeline is OpenCV
+// end to end -- preprocessing, rendering, and display all take cv::Mat -- so
+// frames are bridged here, at the single point video enters the app, rather
+// than teaching every stage a second image type.
+//
+// Returns a BGR8 cv::Mat, the layout every downstream stage already assumes.
+//
+// On the common path (a packed BGR8 frame, which is what all three capture
+// backends currently produce) the result is a header *aliasing* the frame's
+// own storage: no pixels are copied, and writes through the Mat -- the FPS
+// overlay, the rendered detections -- land in the frame's buffer. Two
+// consequences follow from that alias:
+//
+//   * The Mat is valid only until the next readFrame() on the same frame.
+//     Frame::resize() may reallocate, which leaves any earlier Mat dangling,
+//     so convert after each read rather than hoisting the Mat out of the loop.
+//   * Anything that must outlive the next read needs its own copy (.clone()).
+//
+// Any other pixel format is converted into a freshly allocated buffer, so the
+// Mat owns its pixels and writes do not reach the frame. Callers that only
+// read, render, and display -- which is all of them today -- need not care
+// which of the two they were handed.
+//
+// An empty frame converts to an empty Mat. A frame whose planar layout is not
+// the canonical tightly packed one throws std::invalid_argument rather than
+// reinterpreting the bytes as something they are not.
+cv::Mat toBgrMat(videocapture::Frame &frame);
+
+} // namespace neuriplo_infer

--- a/app/src/CLICommands.cpp
+++ b/app/src/CLICommands.cpp
@@ -1,5 +1,6 @@
 #include "CLICommands.hpp"
 
+#include "FrameConversion.hpp"
 #include "VideoCaptureFactory.hpp"
 #include "neuriplo/tasks/core/opencv_interop.hpp"
 #ifdef NEURIPLO_INFER_WITH_KSERVE
@@ -318,7 +319,7 @@ void processVideo(InferencePipeline &pipeline, const std::string &source) {
     }
   }
 
-  cv::Mat frame;
+  videocapture::Frame frame;
   bool read_to_end = false;
   while (true) {
     bool read_frame = false;
@@ -335,8 +336,12 @@ void processVideo(InferencePipeline &pipeline, const std::string &source) {
       break;
     }
 
+    // Bridged per read, not once outside the loop: the Mat aliases the
+    // frame's storage, which readFrame may reallocate.
+    cv::Mat image = neuriplo_infer::toBgrMat(frame);
+
     auto start = std::chrono::steady_clock::now();
-    auto results = inferFrame(pipeline, frame, nullptr);
+    auto results = inferFrame(pipeline, image, nullptr);
     if (pipeline.report != nullptr) {
       pipeline.report->addFrames(1);
     }
@@ -352,10 +357,10 @@ void processVideo(InferencePipeline &pipeline, const std::string &source) {
       // way the written PNG is for a still image.
       neuriplo_infer::StageTimer render_timer(pipeline.report,
                                               neuriplo_infer::RunStage::Render);
-      cv::putText(frame, fpsText, cv::Point(10, 30), cv::FONT_HERSHEY_SIMPLEX,
+      cv::putText(image, fpsText, cv::Point(10, 30), cv::FONT_HERSHEY_SIMPLEX,
                   1, cv::Scalar(0, 255, 0), 2);
-      pipeline.renderResults(results, frame);
-      cv::imshow("opencv feed", frame);
+      pipeline.renderResults(results, image);
+      cv::imshow("opencv feed", image);
     }
 
     const int key = cv::waitKey(1);
@@ -391,7 +396,7 @@ void processVideoClassification(InferencePipeline &pipeline,
   LOG(INFO) << "Video classification mode: accumulating " << requiredFrames
             << " frames";
 
-  cv::Mat frame;
+  videocapture::Frame frame;
   std::vector<cv::Mat> frameBuffer;
   frameBuffer.reserve(static_cast<size_t>(requiredFrames));
 
@@ -407,7 +412,10 @@ void processVideoClassification(InferencePipeline &pipeline,
       read_to_end = true;
       break;
     }
-    frameBuffer.push_back(frame.clone());
+    // clone(): the window outlives the next read, and on the packed-BGR8
+    // path the bridged Mat is only a view onto storage that read reuses.
+    cv::Mat image = neuriplo_infer::toBgrMat(frame);
+    frameBuffer.push_back(image.clone());
 
     if (static_cast<int>(frameBuffer.size()) >= requiredFrames) {
       auto start = std::chrono::steady_clock::now();
@@ -427,7 +435,7 @@ void processVideoClassification(InferencePipeline &pipeline,
         neuriplo_infer::StageTimer timer(pipeline.report,
                                          neuriplo_infer::RunStage::Postprocess);
         auto tensors = convertToTensors(outputs, shapes);
-        return pipeline.task->postprocess(toTaskSize(frame), tensors);
+        return pipeline.task->postprocess(toTaskSize(image), tensors);
       }();
       // One inference consumes the whole accumulated window.
       if (pipeline.report != nullptr) {

--- a/app/src/FrameConversion.cpp
+++ b/app/src/FrameConversion.cpp
@@ -1,0 +1,130 @@
+#include "FrameConversion.hpp"
+
+#include <opencv2/imgproc.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace neuriplo_infer {
+
+namespace {
+
+using videocapture::Frame;
+using videocapture::PixelFormat;
+
+std::string formatName(PixelFormat format) {
+  switch (format) {
+  case PixelFormat::Gray8:
+    return "Gray8";
+  case PixelFormat::RGB8:
+    return "RGB8";
+  case PixelFormat::BGR8:
+    return "BGR8";
+  case PixelFormat::RGBA8:
+    return "RGBA8";
+  case PixelFormat::BGRA8:
+    return "BGRA8";
+  case PixelFormat::NV12:
+    return "NV12";
+  case PixelFormat::YUV420P:
+    return "YUV420P";
+  }
+  return "unknown";
+}
+
+// A Mat header over one plane. No pixels are copied, and the frame's own row
+// stride is passed through, so a plane with padded rows maps correctly instead
+// of being read as if it were tightly packed.
+cv::Mat planeHeader(Frame &frame, int type, std::size_t plane = 0) {
+  return cv::Mat(frame.planeHeight(plane), frame.planeWidth(plane), type,
+                 frame.data(plane), frame.rowStride(plane));
+}
+
+// OpenCV decodes NV12 and YUV420P from a single-channel buffer holding the
+// luma rows followed by the chroma rows, all at the luma row pitch. That is
+// exactly Frame's canonical layout for even dimensions -- but only for even
+// dimensions, and only while the planes stay tightly packed and adjacent, so
+// verify rather than assume. Getting this wrong would not fail loudly; it
+// would silently produce a picture with the colors torn out of place.
+cv::Mat planarLumaChromaHeader(Frame &frame,
+                               const std::vector<std::size_t> &chromaStrides) {
+  const int width = frame.width();
+  const int height = frame.height();
+  if (width % 2 != 0 || height % 2 != 0) {
+    throw std::invalid_argument(
+        "videocapture::Frame in " + formatName(frame.format()) + " is " +
+        std::to_string(width) + "x" + std::to_string(height) +
+        "; planar 4:2:0 conversion requires even dimensions");
+  }
+
+  if (frame.rowStride(0) != static_cast<std::size_t>(width)) {
+    throw std::invalid_argument(
+        "videocapture::Frame in " + formatName(frame.format()) +
+        " has a padded luma plane; planar 4:2:0 conversion requires a tightly "
+        "packed layout");
+  }
+
+  const std::uint8_t *expected = frame.data(0) + frame.sizeBytes(0);
+  for (std::size_t plane = 1; plane <= chromaStrides.size(); ++plane) {
+    if (frame.rowStride(plane) != chromaStrides[plane - 1] ||
+        frame.data(plane) != expected) {
+      throw std::invalid_argument(
+          "videocapture::Frame in " + formatName(frame.format()) +
+          " does not use the tightly packed plane layout that planar 4:2:0 "
+          "conversion requires");
+    }
+    expected += frame.sizeBytes(plane);
+  }
+
+  // Luma rows plus the chroma rows that follow, both at the luma pitch.
+  return cv::Mat(height + height / 2, width, CV_8UC1, frame.data(0),
+                 static_cast<std::size_t>(width));
+}
+
+} // namespace
+
+cv::Mat toBgrMat(Frame &frame) {
+  if (frame.empty()) {
+    return {};
+  }
+
+  cv::Mat converted;
+  switch (frame.format()) {
+  case PixelFormat::BGR8:
+    // The only zero-copy case, and the one every capture backend produces
+    // today: already the layout the rest of the app works in.
+    return planeHeader(frame, CV_8UC3);
+  case PixelFormat::RGB8:
+    cv::cvtColor(planeHeader(frame, CV_8UC3), converted, cv::COLOR_RGB2BGR);
+    return converted;
+  case PixelFormat::Gray8:
+    cv::cvtColor(planeHeader(frame, CV_8UC1), converted, cv::COLOR_GRAY2BGR);
+    return converted;
+  case PixelFormat::RGBA8:
+    cv::cvtColor(planeHeader(frame, CV_8UC4), converted, cv::COLOR_RGBA2BGR);
+    return converted;
+  case PixelFormat::BGRA8:
+    cv::cvtColor(planeHeader(frame, CV_8UC4), converted, cv::COLOR_BGRA2BGR);
+    return converted;
+  case PixelFormat::NV12: {
+    const std::size_t width = static_cast<std::size_t>(frame.width());
+    cv::cvtColor(planarLumaChromaHeader(frame, {width}), converted,
+                 cv::COLOR_YUV2BGR_NV12);
+    return converted;
+  }
+  case PixelFormat::YUV420P: {
+    const std::size_t chroma = static_cast<std::size_t>(frame.width()) / 2;
+    cv::cvtColor(planarLumaChromaHeader(frame, {chroma, chroma}), converted,
+                 cv::COLOR_YUV2BGR_I420);
+    return converted;
+  }
+  }
+
+  throw std::invalid_argument("videocapture::Frame carries an unrecognized "
+                              "pixel format and cannot be converted to BGR");
+}
+
+} // namespace neuriplo_infer

--- a/app/test/CMakeLists.txt
+++ b/app/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(${PROJECT_NAME_TEST}
     ${CMAKE_CURRENT_LIST_DIR}/test_parseCommandLineArguments.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_NeuriploInfer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_InferencePipelineBuilder.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_FrameConversion.cpp
     # The pure KServe protocol/retry/security suites live in the
     # neuriplo-kserve-client repo; only the adapter test stays here.
     ${CMAKE_CURRENT_LIST_DIR}/test_KserveEngine.cpp

--- a/app/test/test_FrameConversion.cpp
+++ b/app/test/test_FrameConversion.cpp
@@ -1,0 +1,151 @@
+#include "FrameConversion.hpp"
+
+#include <gtest/gtest.h>
+#include <opencv2/imgproc.hpp>
+
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+using neuriplo_infer::toBgrMat;
+using videocapture::Frame;
+using videocapture::PixelFormat;
+
+namespace {
+
+// Fills a packed frame with a per-pixel pattern so a channel swap cannot pass
+// by symmetry the way a solid color would.
+void fillPacked(Frame &frame, const std::vector<std::uint8_t> &pixel) {
+  for (int y = 0; y < frame.height(); ++y) {
+    std::uint8_t *row = frame.data() + y * frame.rowStride();
+    for (int x = 0; x < frame.width(); ++x) {
+      for (std::size_t c = 0; c < pixel.size(); ++c) {
+        row[x * pixel.size() + c] =
+            static_cast<std::uint8_t>(pixel[c] + x + 2 * y);
+      }
+    }
+  }
+}
+
+cv::Mat solidBgr(int width, int height, cv::Scalar color) {
+  return cv::Mat(height, width, CV_8UC3, color);
+}
+
+} // namespace
+
+TEST(FrameConversionTest, EmptyFrameConvertsToEmptyMat) {
+  Frame frame;
+  EXPECT_TRUE(toBgrMat(frame).empty());
+}
+
+TEST(FrameConversionTest, Bgr8AliasesFrameStorageWithoutCopying) {
+  Frame frame(4, 3, PixelFormat::BGR8);
+  fillPacked(frame, {10, 20, 30});
+
+  cv::Mat mat = toBgrMat(frame);
+  ASSERT_EQ(mat.type(), CV_8UC3);
+  EXPECT_EQ(mat.cols, 4);
+  EXPECT_EQ(mat.rows, 3);
+  // The whole point of the packed-BGR8 path: same bytes, not a copy of them.
+  EXPECT_EQ(mat.data, frame.data());
+
+  // ...which is what makes the render overlay land in the frame's buffer.
+  mat.at<cv::Vec3b>(1, 2) = cv::Vec3b(7, 8, 9);
+  const std::uint8_t *pixel = frame.data() + frame.rowStride() + 2 * 3;
+  EXPECT_EQ(pixel[0], 7);
+  EXPECT_EQ(pixel[1], 8);
+  EXPECT_EQ(pixel[2], 9);
+}
+
+TEST(FrameConversionTest, Rgb8IsReorderedToBgr) {
+  Frame frame(4, 3, PixelFormat::RGB8);
+  fillPacked(frame, {10, 20, 30});
+
+  cv::Mat mat = toBgrMat(frame);
+  ASSERT_EQ(mat.type(), CV_8UC3);
+  EXPECT_NE(mat.data, frame.data()) << "a conversion must not alias the frame";
+
+  const std::uint8_t *src = frame.data() + frame.rowStride() + 2 * 3;
+  const cv::Vec3b converted = mat.at<cv::Vec3b>(1, 2);
+  EXPECT_EQ(converted[0], src[2]);
+  EXPECT_EQ(converted[1], src[1]);
+  EXPECT_EQ(converted[2], src[0]);
+}
+
+TEST(FrameConversionTest, Gray8IsReplicatedAcrossBgrChannels) {
+  Frame frame(4, 3, PixelFormat::Gray8);
+  fillPacked(frame, {40});
+
+  cv::Mat mat = toBgrMat(frame);
+  ASSERT_EQ(mat.type(), CV_8UC3);
+  const std::uint8_t gray = *(frame.data() + frame.rowStride() + 2);
+  EXPECT_EQ(mat.at<cv::Vec3b>(1, 2), cv::Vec3b(gray, gray, gray));
+}
+
+TEST(FrameConversionTest, AlphaFormatsDropAlphaAndKeepBgrOrder) {
+  Frame rgba(4, 3, PixelFormat::RGBA8);
+  fillPacked(rgba, {10, 20, 30, 255});
+  const std::uint8_t *rgbaPixel = rgba.data() + rgba.rowStride() + 2 * 4;
+  const cv::Vec3b fromRgba = toBgrMat(rgba).at<cv::Vec3b>(1, 2);
+  EXPECT_EQ(fromRgba, cv::Vec3b(rgbaPixel[2], rgbaPixel[1], rgbaPixel[0]));
+
+  Frame bgra(4, 3, PixelFormat::BGRA8);
+  fillPacked(bgra, {10, 20, 30, 255});
+  const std::uint8_t *bgraPixel = bgra.data() + bgra.rowStride() + 2 * 4;
+  const cv::Vec3b fromBgra = toBgrMat(bgra).at<cv::Vec3b>(1, 2);
+  EXPECT_EQ(fromBgra, cv::Vec3b(bgraPixel[0], bgraPixel[1], bgraPixel[2]));
+}
+
+// The planar cases are the ones where a wrong plane layout would not fail --
+// it would quietly decode a picture with the color torn out of place -- so
+// they are checked against OpenCV's own I420 encoding of a known image.
+TEST(FrameConversionTest, Yuv420pDecodesToTheOriginalColor) {
+  const cv::Scalar color(32, 96, 200); // BGR
+  cv::Mat i420;
+  cv::cvtColor(solidBgr(8, 6, color), i420, cv::COLOR_BGR2YUV_I420);
+  ASSERT_TRUE(i420.isContinuous());
+
+  Frame frame(8, 6, PixelFormat::YUV420P);
+  ASSERT_EQ(frame.storageSizeBytes(), i420.total());
+  std::memcpy(frame.data(), i420.data, i420.total());
+
+  cv::Mat bgr = toBgrMat(frame);
+  ASSERT_EQ(bgr.size(), cv::Size(8, 6));
+  const cv::Vec3b decoded = bgr.at<cv::Vec3b>(3, 4);
+  EXPECT_NEAR(decoded[0], color[0], 3);
+  EXPECT_NEAR(decoded[1], color[1], 3);
+  EXPECT_NEAR(decoded[2], color[2], 3);
+}
+
+TEST(FrameConversionTest, Nv12DecodesToTheOriginalColor) {
+  const cv::Scalar color(32, 96, 200); // BGR
+  cv::Mat i420;
+  cv::cvtColor(solidBgr(8, 6, color), i420, cv::COLOR_BGR2YUV_I420);
+
+  // NV12 is I420 with the two chroma planes interleaved.
+  Frame frame(8, 6, PixelFormat::NV12);
+  const std::size_t lumaBytes = 8 * 6;
+  const std::size_t chromaSamples = (8 / 2) * (6 / 2);
+  ASSERT_EQ(frame.storageSizeBytes(), lumaBytes + 2 * chromaSamples);
+  std::memcpy(frame.data(0), i420.data, lumaBytes);
+  const std::uint8_t *u = i420.data + lumaBytes;
+  const std::uint8_t *v = u + chromaSamples;
+  std::uint8_t *chroma = frame.data(1);
+  for (std::size_t i = 0; i < chromaSamples; ++i) {
+    chroma[2 * i] = u[i];
+    chroma[2 * i + 1] = v[i];
+  }
+
+  const cv::Vec3b decoded = toBgrMat(frame).at<cv::Vec3b>(3, 4);
+  EXPECT_NEAR(decoded[0], color[0], 3);
+  EXPECT_NEAR(decoded[1], color[1], 3);
+  EXPECT_NEAR(decoded[2], color[2], 3);
+}
+
+TEST(FrameConversionTest, OddSized420FrameIsRejectedRatherThanMisread) {
+  // Frame allows odd dimensions by rounding the chroma planes up, which breaks
+  // the single-buffer layout OpenCV's 4:2:0 decoders require. Refusing beats
+  // handing back a plausible-looking picture built from misaligned bytes.
+  Frame frame(7, 6, PixelFormat::NV12);
+  EXPECT_THROW(toBgrMat(frame), std::invalid_argument);
+}

--- a/versions.env
+++ b/versions.env
@@ -26,6 +26,6 @@ CMAKE_MIN_VERSION=3.20
 # so a checkout of the v0.9.1 tag rebuilds against the exact same sibling code.
 # Siblings version independently -- these need not be equal.
 NEURIPLO_VERSION=v0.8.0
-VIDEOCAPTURE_VERSION=v0.3.0
+VIDEOCAPTURE_VERSION=v0.4.0
 NEURIPLO_TASKS_VERSION=v0.8.0
 NEURIPLO_KSERVE_CLIENT_VERSION=v0.4.0


### PR DESCRIPTION
## Summary

- update the videocapture dependency pin to v0.4.0
- port both capture loops from the removed `cv::Mat` API to `videocapture::Frame`
- bridge packed BGR8 frames to OpenCV without copying
- convert RGB, grayscale, alpha, YUV420P, and NV12 formats with explicit validation
- stop injecting OpenCV into videocapture backends that no longer require it
- preserve the per-inference timings and headless behavior merged in PR #40

## Validation

- release configure and build with `DEFAULT_BACKEND=OPENCV_DNN`
- test configure and build with `ENABLE_APP_TESTS=ON`
- `ctest --test-dir build-test --output-on-failure` — 83/83 passed
- `clang-format-18 --dry-run --Werror` on all changed C++ files
- generated supported-model docs check passed
- `git diff --check` passed

## Runtime evidence

The original feature validation decoded a real 1280x720 clip through the factory and confirmed packed BGR8 storage aliasing, stride 3840, and correct channel order. The conversion suite covers all seven supported pixel formats, including YUV420P and NV12 against OpenCV-generated reference data.