### PR TITLE
docs(specs): plan the OpenCV-free app layer

### DIFF
--- a/specs/2026-08-31-opencv-free-app/plan.md
+++ b/specs/2026-08-31-opencv-free-app/plan.md
@@ -103,32 +103,53 @@ OpenCV stays linked throughout this group; each task is independently revertible
     regression net — run them before and after and diff `--help` output byte for
     byte.
 
-## Group 6 — the display decision
+## Group 6 — the preview window
 
-15. **Implement the option the maintainer picks** for `cv::imshow` /
-    `cv::waitKey` (Open Question 1 in `requirements.md`). Whichever it is, it
-    carries a `CHANGELOG.md` entry, because the video loops' observable
-    behaviour changes. This group is the only one that cannot start before that
-    answer.
+15. **Add `NEURIPLO_INFER_WITH_DISPLAY` (default OFF)** and move the two video
+    loops' `cv::imshow` / `cv::waitKey` behind an SDL2 presenter. The presenter
+    takes an `Image`, owns the window, the texture, and the keypress that ends
+    the loop; the loops must not learn which library is behind it, so a later
+    swap stays a one-file change. SDL2 is discovered only when the flag is ON —
+    a default build must not `find_package(SDL2)` at all, or the dependency
+    becomes required in practice while looking optional.
+
+16. **Make the flag's absence a first-class state.** With the flag OFF, no
+    preview is advertised in `--help` or `--capabilities`, and asking for one
+    fails fast naming the flag and how to rebuild — the repo forbids silent CLI
+    breakage. The default build no longer opens a window, which is a
+    user-visible change and needs a `CHANGELOG.md` entry.
+
+17. **A display build must still run headless.** `NEURIPLO_INFER_WITH_DISPLAY=ON`
+    is a compile-time capability, not a promise that a display exists: the same
+    binary gets run over SSH, in a container, and under CI, where `DISPLAY` is
+    unset and `SDL_Init(SDL_INIT_VIDEO)` fails. That must log once and continue
+    processing without a window, never abort the run — today `cv::imshow` in the
+    same situation throws and takes the whole video with it. This is the one
+    behaviour a compile-time-only flag cannot express on its own.
+
+18. **Verify no headless image gained SDL2.** The +237 MB closure reaching a
+    serving container is the way this feature would quietly undo itself while
+    every build still looked correct; check each `Dockerfile` that does not
+    enable the flag.
 
 ## Group 7 — flip the dependency
 
-16. **Remove `find_package(OpenCV REQUIRED)`** from `CMakeLists.txt`, drop the
+19. **Remove `find_package(OpenCV REQUIRED)`** from `CMakeLists.txt`, drop the
     `neuriplo-tasks::vision-opencv` link and `${OpenCV_LIBS}` / `${OpenCV_INCLUDE_DIRS}`
     from `app/CMakeLists.txt` and `app/test/CMakeLists.txt`, and leave
     `NEURIPLO_TASKS_WITH_OPENCV` at its default `OFF`.
 
-17. **Slim the images.** Drop `libopencv-dev` from every `docker/Dockerfile.*`
+20. **Slim the images.** Drop `libopencv-dev` from every `docker/Dockerfile.*`
     except the `OPENCV_DNN` one, which keeps it because `neuriplo` requires it
     for that backend. Record the image size delta.
 
 ## Group 8 — contract and documentation
 
-18. Update `specs/tech-stack.md` — the "OpenCV ≥ 4.6 and glog are system
+21. Update `specs/tech-stack.md` — the "OpenCV ≥ 4.6 and glog are system
     dependencies" line is what this feature falsifies, and that file requires
     amendment in the same branch as the change. Update `README.md` build
     prerequisites, `CHANGELOG.md`, and the phase status in `../roadmap.md`.
 
-19. Execute [`validation.md`](validation.md) from the file, not from memory.
+22. Execute [`validation.md`](validation.md) from the file, not from memory.
 
 > Commit by group — this is higher-risk work touching every rendering path.

--- a/specs/2026-08-31-opencv-free-app/plan.md
+++ b/specs/2026-08-31-opencv-free-app/plan.md
@@ -1,0 +1,134 @@
+# Feature Plan — OpenCV-free application layer
+
+Derived from [`requirements.md`](requirements.md). Groups are in dependency
+order. Every group ends with the tree building and `ctest` green — OpenCV stays
+linked until Group 7, so no group leaves a broken intermediate state.
+
+Groups 1 and 5–8 are `neuriplo-tasks` and `neuriplo-infer` respectively; Group 1
+must be released and pinned before this branch can be released, though local
+sibling resolution unblocks development immediately.
+
+## Group 1 — `neuriplo-tasks`: the drawing layer
+
+Delivered in `neuriplo-tasks` as `neuriplo_tasks::vision::draw`, beside
+`vision::ops`. It operates on `Image` and knows nothing of `Result` types.
+
+1. **Fill the two API gaps.** Add `Interpolation::Nearest` to `vision::ops`
+   (the mask overlay needs `INTER_NEAREST`; the enum currently has Linear, Area,
+   Cubic only). Add `encodeImage(const Image&, Format, std::vector<uint8_t>&)`
+   to `stb_io`, via `stbi_write_jpg_to_func` / `stbi_write_png_to_func` —
+   `stb_image_write.h` is already vendored, and only `loadImage`/`decodeImage`/
+   `saveImage` are exposed today.
+
+2. **Primitive rasterizer.** `drawLine`, `drawRectangle` (stroked and filled),
+   `drawCircle` (filled), `drawPolyline` (open and closed), each taking a colour,
+   a thickness, and an anti-alias flag. Thick strokes are rendered as the union
+   of the segment's offset outline so joins do not gap — matching what
+   `cv::polylines` with `thickness=2` produces. Anti-aliasing uses per-pixel
+   coverage; the un-AA path is Bresenham.
+
+3. **Composite operations.** `blend(dst, src, alpha)` for the mask overlay
+   (`cv::addWeighted(image, 1, colorMask, 0.7, 0, image)`), `fillMasked(dst,
+   mask, colour)` for `Mat::setTo(colour, mask)`, and `applyColormap(Image&,
+   Colormap::Turbo)` from a vendored 256-entry LUT.
+
+4. **Hershey text.** Vendor the SIMPLEX and DUPLEX glyph tables for ASCII 32–126
+   under `3rdparty/hershey/` with their provenance notice, then implement
+   `drawText(Image&, text, origin, scale, colour, thickness)` and
+   `measureText(text, scale, thickness) -> {Size, baseline}` on top of the
+   polyline rasterizer from step 2. `measureText` must reproduce
+   `cv::getTextSize`'s contract, because `utils::draw_label` sizes its filled
+   background rectangle from it — a wrong width there is a visibly clipped label,
+   not a subtle shading difference.
+
+5. **Differential tests against OpenCV.** For each primitive, draw the same
+   shape into an `Image` via `vision::draw` and into a `cv::Mat` via OpenCV, and
+   assert agreement within the tolerance fixed in `validation.md`. These build
+   only when `NEURIPLO_TASKS_WITH_OPENCV=ON`, so they run in `build-ocv` and are
+   absent from `build-no-ocv` — OpenCV becomes a test-only dependency of tasks
+   and never a runtime one.
+
+## Group 2 — `neuriplo-infer`: mechanical replacements
+
+OpenCV stays linked throughout this group; each task is independently revertible.
+
+6. **Image I/O.** `cv::imread` → `loadImage`, `cv::imwrite` → `saveImage`,
+   `cv::imencode(".jpg", …)` → `encodeImage` (the KServe encoded-image path).
+   Preserve the existing failure behaviour, including the fallback-path retry in
+   `CLICommands.cpp`.
+
+7. **Pixel ops.** `cv::resize` → `ops::resize`, `cv::normalize(NORM_MINMAX)` →
+   `ops::minMax` plus `Image::convertTo`, `cv::cvtColor` → `ops::swapBgrRgb`
+   where it is a channel swap.
+
+8. **Delete the `cv::cuda` probes** in `utils.cpp`, keeping the filesystem
+   fallbacks that already sit below them. Confirm `getGPUModels()` still reports
+   model names on a GPU host.
+
+## Group 3 — `neuriplo-infer`: the image type
+
+9. **Migrate `cv::Mat` → `neuriplo_tasks::Image`** through the app's own
+   signatures: `AppConfig`, `CLICommands`, `InferencePipeline::renderResults`,
+   `utils`, and the `ResultRenderer` interface. To keep this group mechanical,
+   `ResultRenderer` keeps its OpenCV body behind a **zero-copy** `Image` →
+   `cv::Mat` view (`cv::Mat(h, w, CV_8UC3, image.data(), image.stride())`,
+   valid because both are packed 8-bit BGR). Group 4 deletes that view.
+
+10. **Drop `FrameConversion`.** With the app on `Image`, the videocapture v0.4.0
+    bridge becomes `Frame` → `Image` — the same aliasing argument, one fewer
+    type. `toTaskImage`/`copyFromCvMat` disappear along with it, since frames
+    arrive as `Image` already.
+
+## Group 4 — `neuriplo-infer`: the renderer
+
+11. **Rewrite `ResultRenderer` on `vision::draw`**, one task type at a time —
+    detection, open-vocab detection, classification, video classification,
+    instance segmentation (mask *and* polygon paths), optical flow, pose,
+    depth, image understanding. Colours, thicknesses, font scales, the skeleton
+    edge list, and the `std::rand()` colour draw are reproduced exactly; see
+    *Out of Scope* in `requirements.md`.
+
+12. **Rewrite `utils::draw_label`** on `measureText` + filled rectangle + text.
+
+13. **Delete the temporary `cv::Mat` view** from step 9. At this point `app/`
+    contains no `cv::` outside the display calls.
+
+## Group 5 — `neuriplo-infer`: the CLI parser
+
+14. **Replace `cv::CommandLineParser`** with a small parser preserving the
+    current surface: `--key=value`, `-k value`, defaults, `has()`, typed `get()`,
+    and the generated help text. The four call sites are thin; the 429 lines
+    around them are validation that does not change. `test_parseCommandLineArguments`,
+    `capabilities_cli_contract`, and `capabilities_schema_contract` are the
+    regression net — run them before and after and diff `--help` output byte for
+    byte.
+
+## Group 6 — the display decision
+
+15. **Implement the option the maintainer picks** for `cv::imshow` /
+    `cv::waitKey` (Open Question 1 in `requirements.md`). Whichever it is, it
+    carries a `CHANGELOG.md` entry, because the video loops' observable
+    behaviour changes. This group is the only one that cannot start before that
+    answer.
+
+## Group 7 — flip the dependency
+
+16. **Remove `find_package(OpenCV REQUIRED)`** from `CMakeLists.txt`, drop the
+    `neuriplo-tasks::vision-opencv` link and `${OpenCV_LIBS}` / `${OpenCV_INCLUDE_DIRS}`
+    from `app/CMakeLists.txt` and `app/test/CMakeLists.txt`, and leave
+    `NEURIPLO_TASKS_WITH_OPENCV` at its default `OFF`.
+
+17. **Slim the images.** Drop `libopencv-dev` from every `docker/Dockerfile.*`
+    except the `OPENCV_DNN` one, which keeps it because `neuriplo` requires it
+    for that backend. Record the image size delta.
+
+## Group 8 — contract and documentation
+
+18. Update `specs/tech-stack.md` — the "OpenCV ≥ 4.6 and glog are system
+    dependencies" line is what this feature falsifies, and that file requires
+    amendment in the same branch as the change. Update `README.md` build
+    prerequisites, `CHANGELOG.md`, and the phase status in `../roadmap.md`.
+
+19. Execute [`validation.md`](validation.md) from the file, not from memory.
+
+> Commit by group — this is higher-risk work touching every rendering path.

--- a/specs/2026-08-31-opencv-free-app/requirements.md
+++ b/specs/2026-08-31-opencv-free-app/requirements.md
@@ -69,6 +69,13 @@ requires this work — it is entirely an application-layer concern.
 - **`neuriplo-track`, `tritonic`, `object-detection-inference`.** They can adopt
   `vision::draw` once it exists; that is their own work.
 - **GPU-accelerated drawing.** The rasterizer is scalar CPU code.
+- **Video output.** Annotated results stay per-frame stills here. A writer is
+  going into `videocapture` as a sink mirroring `readFrame`, which is where the
+  repo boundary puts it — `specs/tech-stack.md` states *"No video-backend
+  selection policy here. `videocapture` owns priority and source semantics"* —
+  and where the FFmpeg integration already exists, so with `-DUSE_FFMPEG=ON` it
+  costs nothing new. This branch must not grow an encoder, and must not link
+  FFmpeg: consuming that sink is a later, separate change here.
 - **Removing OpenCV from the `OPENCV_DNN` image.** That backend *is* OpenCV;
   it keeps it, `PRIVATE`, via `neuriplo`. This feature makes that the only
   place it appears.

--- a/specs/2026-08-31-opencv-free-app/requirements.md
+++ b/specs/2026-08-31-opencv-free-app/requirements.md
@@ -1,0 +1,171 @@
+# Feature Requirements — OpenCV-free application layer
+
+Roadmap phase: [Candidates → *OpenCV-free application layer*](../roadmap.md)
+Branch: `feature/opencv-free-app`
+
+## Goal
+
+`neuriplo-infer` builds, runs, renders, and writes results with no OpenCV of its
+own, so OpenCV becomes an internal detail of a single neuriplo backend
+(`OPENCV_DNN`) rather than a system dependency of the application. A TensorRT,
+ONNX Runtime, LibTorch, or KServe-only build then configures, links, and ships
+without OpenCV present at all.
+
+## Why this is achievable now
+
+Three of the four repos in the cluster already made this move; only the
+application still opts in:
+
+| Repo | State | Evidence |
+|---|---|---|
+| `neuriplo` | **Done.** OpenCV is requested only by the `OPENCV_DNN` backend, linked `PRIVATE` | the single `find_package(OpenCV REQUIRED)` sits inside the `OPENCV_DNN` branch of `cmake/LinkBackend.cmake`, with a comment stating exactly this intent |
+| `neuriplo-tasks` | **Done.** OpenCV is an optional adapter, default OFF | `NEURIPLO_TASKS_WITH_OPENCV` defaults `OFF`; dependency-free `Image`/`ImageView`, stb I/O, and an `image_ops` layer whose comment reads *"Replaces cv::resize"* |
+| `videocapture` | **Done in v0.4.0.** `cv::Mat` removed from the public frame API | `readFrame()` fills a `videocapture::Frame`; OpenCV is confined to the OpenCV capture backend |
+| `neuriplo-infer` | **Outstanding.** `find_package(OpenCV REQUIRED)` is unconditional at `CMakeLists.txt:82` | a TensorRT build drags in OpenCV that neither sibling asked for |
+
+The inference contract is already OpenCV-free: `InferenceInterface::get_infer_results`
+takes `std::vector<std::vector<uint8_t>>`. Nothing about the inference path
+requires this work — it is entirely an application-layer concern.
+
+## Scale of the change
+
+~140 `cv::` uses in `app/`, very unevenly distributed:
+
+| Bucket | Sites | Replacement | Notes |
+|---|---|---|---|
+| Rendering | ~70 | new `vision::draw` in `neuriplo-tasks` | the substance of this feature |
+| Image I/O (`imread`/`imwrite`) | 9 | `loadImage` / `saveImage` | exists in tasks |
+| Pixel ops (`resize`, `normalize`, `convertTo`) | ~8 | `image_ops`, `Image::convertTo` | exists; needs `Nearest` |
+| `cv::CommandLineParser` | 4 | hand-rolled parser | contract-guarded by existing tests |
+| `cv::cuda` GPU probe | 3 | delete | filesystem fallbacks already exist below it |
+| `cv::imencode(".jpg")` | 1 | `encodeImage` | **gap** — tasks has decode, not encode |
+| Display (`imshow`/`waitKey`) | 4 | see Open Questions | the one unresolved decision |
+
+## In Scope
+
+- Every `cv::` use in `app/`, including `app/test/`.
+- The application's image type: `cv::Mat` → `neuriplo_tasks::Image` through
+  `AppConfig`, `CLICommands`, `InferencePipeline`, `ResultRenderer`, `utils`.
+- A primitive rasterizer in `neuriplo-tasks` (`vision::draw`) covering exactly
+  what `ResultRenderer` and `utils::draw_label` use: `line`, `rectangle`
+  (stroked and filled), `circle` (filled), closed `polyline`, masked fill,
+  alpha blend, `TURBO` colormap, and text.
+- Text as vendored Hershey vector glyphs with `drawText` / `measureText`.
+- Two small `neuriplo-tasks` additions: `Interpolation::Nearest` and
+  `encodeImage` (encode to memory).
+- CMake: remove the app's unconditional `find_package(OpenCV REQUIRED)` and its
+  `neuriplo-tasks::vision-opencv` link.
+- Dockerfiles: drop `libopencv-dev` from every image except the `OPENCV_DNN` one.
+- `specs/tech-stack.md`, `README.md`, `CHANGELOG.md`, `../roadmap.md`.
+
+## Out of Scope
+
+- **Rendering policy.** Colors, stroke thicknesses, the COCO skeleton topology,
+  label placement, and the `std::rand()` mask colouring are reproduced exactly
+  as they are. Changing how output *looks* while also changing what draws it
+  would make any visual regression impossible to attribute. Improvements go in a
+  later phase.
+- **`neuriplo`.** Already correct; not touched.
+- **`neuriplo-track`, `tritonic`, `object-detection-inference`.** They can adopt
+  `vision::draw` once it exists; that is their own work.
+- **GPU-accelerated drawing.** The rasterizer is scalar CPU code.
+- **Removing OpenCV from the `OPENCV_DNN` image.** That backend *is* OpenCV;
+  it keeps it, `PRIVATE`, via `neuriplo`. This feature makes that the only
+  place it appears.
+
+## Decisions
+
+1. **The rasterizer lives in `neuriplo-tasks`, not in the app.** `Image` and
+   `image_ops` already live there, and `image_ops` exists precisely to replace
+   `cv::` functions. A rasterizer over `Image` written in the app would invert
+   the layering and be unavailable to `neuriplo-track` and `tritonic`, which
+   draw the same overlays. Rendering *policy* stays in the app's
+   `ResultRenderer`; `vision::draw` knows nothing about `Result` types.
+
+2. **Text uses Hershey vector fonts, not stb_truetype or a bundled TTF.**
+   `FONT_HERSHEY_SIMPLEX` and `FONT_HERSHEY_DUPLEX` — the only two fonts this
+   app uses — *are* the public-domain Hershey fonts, whose glyphs are polylines.
+   Rendering them reuses the polyline rasterizer needed anyway for
+   `cv::polylines`, reproduces the same glyph shapes and the same `getTextSize`
+   advance metrics, and ships no font file, no font loader, and no runtime font
+   lookup. A TTF path would add a parser, a rasterizer, a file to install, and a
+   different-looking result. Glyph data is vendored under `3rdparty/`, as stb
+   already is, with its provenance notice.
+
+3. **No SDL2.** `specs/tech-stack.md` forbids a new third-party runtime
+   dependency without maintainer approval and states *"No GUI, no server, no
+   daemon. This is a CLI."* `videocapture` v0.4.0 chose SDL2, but for a
+   top-level sample application, which is a different constraint. See Open
+   Questions — this is the one decision this packet does not make.
+
+4. **The replacement is validated against OpenCV, while OpenCV is still there.**
+   `neuriplo-tasks` already builds both ways (`build-ocv` / `build-no-ocv`), so
+   each primitive gets a test that draws the same shape with OpenCV and with
+   `vision::draw` and asserts the difference is within tolerance. OpenCV becomes
+   a *test-only* dependency of tasks and then leaves the app entirely. This is
+   what turns "hand-rolled rasterizer" from a risk into a measured claim.
+
+5. **Phased so that every group ships green with OpenCV still linked.** The
+   `find_package` removal is the last step, not the first. During the type
+   migration a zero-copy `Image` → `cv::Mat` view keeps the untouched renderer
+   working, so no group leaves the tree broken.
+
+## Constraints and Context
+
+- **`specs/tech-stack.md` states "OpenCV ≥ 4.6 and glog are system
+  dependencies."** This feature changes that rule, so tech-stack.md is updated
+  in this branch — the file's own instruction.
+- **"No new third-party runtime dependency without maintainer approval."**
+  Honoured: Hershey glyph data is vendored public-domain data, not a dependency,
+  and no library is added. Only the display question could violate this.
+- **"No silent CLI breakage."** Any change to the live preview is a reviewed
+  contract change with a `CHANGELOG.md` entry.
+- **The `--capabilities` contract is unaffected.** Neither `Capabilities.cpp`
+  nor `docs/capabilities.schema.json` mentions OpenCV, so no `schema_version`
+  bump. The existing `capabilities_cli_contract` and
+  `capabilities_schema_contract` tests become the safety net for the CLI parser
+  rewrite.
+- **Deleting the `cv::cuda` probe loses nothing.** `getGPUModels()` and
+  `hasNvidiaGPU()` already fall through to `/proc/driver/nvidia/gpus/*/information`,
+  which reports model names. Stock Ubuntu OpenCV is built without CUDA, so
+  `getCudaEnabledDeviceCount()` already returns 0 and the fallback already does
+  all the work on every machine that is not running a custom OpenCV.
+- **Cross-repo sequencing.** `neuriplo-tasks` must release `vision::draw`,
+  `Interpolation::Nearest`, and `encodeImage` before this app change can be
+  released, since `versions.env` pins concrete tags
+  (`scripts/validate_release_pins.sh` blocks a branch pin). Development can
+  resolve the local sibling checkout; the release cannot.
+- **Depends on `feature/videocapture-0.4.0`.** That branch adds
+  `FrameConversion` (`Frame` → `cv::Mat`); this feature deletes it in favour of
+  `Frame` → `Image`. Landing them in the other order means writing the bridge
+  twice.
+
+## Open Questions
+
+1. **What replaces the live preview window?** `cv::imshow` / `cv::waitKey` in
+   the two video loops is the only OpenCV use with no in-family replacement.
+   Three options, and the maintainer picks:
+
+   - **(a) Drop it.** Annotated frames or a video file are written instead.
+     No new dependency, and it is what *"No GUI, no server, no daemon. This is a
+     CLI."* already says. Loses live monitoring; a CLI contract change.
+   - **(b) SDL2 behind `NEURIPLO_INFER_WITH_DISPLAY`, default OFF.** Preserves
+     the feature and matches what `videocapture` v0.4.0 did. Requires explicit
+     maintainer approval for a new runtime dependency, and sits in tension with
+     the no-GUI rule.
+   - **(c) Keep OpenCV as an optional display-only component.** Headless images
+     (the whole point) drop it; anyone wanting a preview installs it. Cheapest,
+     but leaves an OpenCV code path in the app forever.
+
+   Everything else in this packet is independent of this answer, so the other
+   groups can proceed while it is open.
+
+2. **What pixel tolerance counts as parity** for the anti-aliased primitives?
+   Exact match with OpenCV is not a goal and not achievable — OpenCV's AA uses
+   its own fixed-point coverage model. Proposal: assert per-pixel |Δ| ≤ 8 on
+   ≥ 99% of pixels for AA strokes and exact match for un-AA fills, plus layout
+   invariants for text rather than pixel equality.
+
+3. **Does `neuriplo-tasks::vision-opencv` survive?** After this, the app is its
+   only consumer. Keeping it costs nothing and helps external adopters; removing
+   it deletes the last `cv::Mat` interop in the family. Not urgent either way.

--- a/specs/2026-08-31-opencv-free-app/requirements.md
+++ b/specs/2026-08-31-opencv-free-app/requirements.md
@@ -39,7 +39,7 @@ requires this work — it is entirely an application-layer concern.
 | `cv::CommandLineParser` | 4 | hand-rolled parser | contract-guarded by existing tests |
 | `cv::cuda` GPU probe | 3 | delete | filesystem fallbacks already exist below it |
 | `cv::imencode(".jpg")` | 1 | `encodeImage` | **gap** — tasks has decode, not encode |
-| Display (`imshow`/`waitKey`) | 4 | see Open Questions | the one unresolved decision |
+| Display (`imshow`/`waitKey`) | 4 | SDL2 behind `NEURIPLO_INFER_WITH_DISPLAY` | default OFF; see Decision 3 |
 
 ## In Scope
 
@@ -92,11 +92,51 @@ requires this work — it is entirely an application-layer concern.
    different-looking result. Glyph data is vendored under `3rdparty/`, as stb
    already is, with its provenance notice.
 
-3. **No SDL2.** `specs/tech-stack.md` forbids a new third-party runtime
-   dependency without maintainer approval and states *"No GUI, no server, no
-   daemon. This is a CLI."* `videocapture` v0.4.0 chose SDL2, but for a
-   top-level sample application, which is a different constraint. See Open
-   Questions — this is the one decision this packet does not make.
+3. **The live preview is kept, backed by SDL2, behind
+   `NEURIPLO_INFER_WITH_DISPLAY` (default OFF).** `cv::imshow` / `cv::waitKey`
+   is the only OpenCV use with no in-family replacement, and the maintainer
+   chose to keep the capability rather than lose it: SDL2 hands over a window,
+   an event loop, and `SDL_UpdateTexture` + `SDL_RenderCopy`, and it is the
+   choice `videocapture` v0.4.0 already made for the same problem.
+
+   This is a deliberate, approved exception to *"No new third-party runtime
+   dependency without maintainer approval"* in `specs/tech-stack.md`. It is
+   narrow on purpose: the flag defaults OFF, so no headless or serving image
+   acquires SDL2 or anything it pulls, and the exception is recorded here rather
+   than left implicit in a CMake option.
+
+   Measured before deciding, installed-size delta with `--no-install-recommends`,
+   on `ubuntu:24.04` and on `nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04` (the
+   TensorRT base). The two agree within 1 MB, so the CUDA image carries no GL of
+   its own:
+
+   | Option | Added | What dominates |
+   |---|---:|---|
+   | Raw X11 (`libx11-6` + `libxext6`) | +4 MB | nothing — no GL at all |
+   | GLFW · sokol via GLX · `libgl1` alone | +225 MB | `libllvm20` 137 MB + `mesa-libgallium` 42 MB |
+   | sokol via GLES3/EGL | +224 MB | `libegl1` + `libgles2` |
+   | **SDL2 — chosen** | **+237 MB** | the same GL stack; SDL2 itself is 1.9 MB |
+   | OpenCV highgui | +433 MB | Qt5 — Ubuntu builds highgui against Qt5, not GTK |
+   | `libopencv-dev`, installed today | +1088 MB | the full OpenCV stack |
+
+   SDL2 is 4.6x lighter than the highgui it replaces and 4.6x lighter again than
+   what the Dockerfiles install today. It is on record that 225 of its 237 MB is
+   a Mesa/LLVM GL stack a BGR blit never uses, and that raw X11 `XShmPutImage`
+   would be +4 MB — the maintainer weighed that against ~150 lines of
+   hand-written X11 window and event code and chose the library. Because the
+   flag defaults OFF, the difference is paid only by someone who asked for a
+   preview.
+
+   **sokol was evaluated and rejected**, recorded so it is not revisited from
+   scratch. It is a vendored single header under a permissive license, adding no
+   package and fitting the pattern stb and the Hershey data already fit — but it
+   needs a GL context, so it pays GLFW's +225 MB rather than nothing; its Linux
+   window and GL code is, by its own header, *"taken from GLFW"*; and
+   `sokol_app` is an application wrapper that supplies the entry point and
+   drives the program through `init_cb` / `frame_cb`, inverting control away
+   from a CLI that owns its own frame loop. Displaying a frame would also mean a
+   texture upload and a fullscreen quad. It is GLFW's runtime cost, more code
+   than SDL2, plus a header to maintain.
 
 4. **The replacement is validated against OpenCV, while OpenCV is still there.**
    `neuriplo-tasks` already builds both ways (`build-ocv` / `build-no-ocv`), so
@@ -116,8 +156,9 @@ requires this work — it is entirely an application-layer concern.
   dependencies."** This feature changes that rule, so tech-stack.md is updated
   in this branch — the file's own instruction.
 - **"No new third-party runtime dependency without maintainer approval."**
-  Honoured: Hershey glyph data is vendored public-domain data, not a dependency,
-  and no library is added. Only the display question could violate this.
+  SDL2 is that dependency, and Decision 3 records the approval and its bounds:
+  optional, default OFF, display only. Nothing else is added — Hershey glyph
+  data is vendored public-domain data, not a dependency.
 - **"No silent CLI breakage."** Any change to the live preview is a reviewed
   contract change with a `CHANGELOG.md` entry.
 - **The `--capabilities` contract is unaffected.** Neither `Capabilities.cpp`
@@ -142,69 +183,12 @@ requires this work — it is entirely an application-layer concern.
 
 ## Open Questions
 
-1. **What replaces the live preview window?** `cv::imshow` / `cv::waitKey` in
-   the two video loops is the only OpenCV use with no in-family replacement.
-   **Undecided.** Measured evidence, installed-size delta with
-   `--no-install-recommends`, taken on both `ubuntu:24.04` and
-   `nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04` (the TensorRT base) — the two
-   bases agree to within 1 MB, so the CUDA image carries no GL of its own and
-   there is no free lunch there:
-
-   | Option | Added | What dominates |
-   |---|---:|---|
-   | Raw X11 (`libx11-6` + `libxext6`) | **+4 MB** | nothing — no GL at all |
-   | sokol / GLFW X11 libs, without GL | +4 MB | `X11`, `Xi`, `Xcursor` |
-   | GLFW (`libglfw3`) | +225 MB | the GL stack; GLFW itself ≈ 0 |
-   | sokol with `SOKOL_GLCORE` (GLX) | +225 MB | `libgl1` |
-   | sokol with `SOKOL_GLES3` (EGL) | +224 MB | `libegl1` + `libgles2` |
-   | `libgl1` alone, for reference | +225 MB | `libllvm20` 137 MB + `mesa-libgallium` 42 MB |
-   | SDL2 (`libsdl2-2.0-0`) | +237 MB | the same GL stack; SDL2 itself is 1.9 MB |
-   | OpenCV highgui | +433 MB | Qt5 — Ubuntu builds highgui against Qt5, not GTK |
-   | `libopencv-dev`, installed today | +1088 MB | the full OpenCV stack |
-
-   The shape of the table matters more than any single row. **Every GL-based
-   option costs the same ~225 MB**, because Mesa's software GL pulls
-   `libllvm20`. SDL2 is not lighter because SDL2 is small — it is 1.9 MB; 225 of
-   its 237 MB is a GL stack that a window blitting a BGR buffer never uses.
-   The only option that escapes the GL tax is the one that never asks for a
-   context.
-
-   Candidates:
-
-   - **Drop the preview.** Write annotated frames or a video file instead. No
-     dependency at all, and it is what *"No GUI, no server, no daemon. This is a
-     CLI."* in `specs/tech-stack.md` already says. Loses live monitoring; a CLI
-     contract change.
-   - **Raw X11 `XShmPutImage`.** +4 MB, ~60x lighter than SDL2's closure.
-     Create a window, blit a BGRA buffer, read one keypress. ~150 lines,
-     X11-only (works under XWayland). Cheapest by two orders of magnitude and
-     the only option whose cost is proportional to the feature.
-   - **SDL2.** +237 MB. Most batteries included — `SDL_UpdateTexture` +
-     `SDL_RenderCopy`, window and event loop handled — and the precedent
-     `videocapture` v0.4.0 set. Needs approval as a new runtime dependency.
-   - **sokol (`sokol_app` + `sokol_gfx`).** Rejected on evaluation, recorded so
-     it is not revisited from scratch. Attractive because it is a vendored
-     single header under a permissive license, adding no package and fitting the
-     pattern stb and the Hershey data already fit. But three things count
-     against it here: it needs a GL context, so the runtime cost is GLFW's
-     +225 MB and not zero; its Linux window and GL code is, by its own header,
-     *"taken from GLFW"*, so it is GLFW-as-a-header rather than something
-     lighter; and `sokol_app` is an application wrapper that **provides the
-     entry point and drives the program through `init_cb` / `frame_cb`**, which
-     inverts control away from a CLI that owns its own frame loop. Showing a
-     frame also means a texture upload and a fullscreen quad, more code than
-     SDL2's blit and far more than X11's. It is the GL cost of GLFW, more code
-     than SDL2, plus a vendored header to maintain.
-
-   Everything else in this packet is independent of this answer, so the other
-   groups can proceed while it is open.
-
-2. **What pixel tolerance counts as parity** for the anti-aliased primitives?
+1. **What pixel tolerance counts as parity** for the anti-aliased primitives?
    Exact match with OpenCV is not a goal and not achievable — OpenCV's AA uses
    its own fixed-point coverage model. Proposal: assert per-pixel |Δ| ≤ 8 on
    ≥ 99% of pixels for AA strokes and exact match for un-AA fills, plus layout
    invariants for text rather than pixel equality.
 
-3. **Does `neuriplo-tasks::vision-opencv` survive?** After this, the app is its
+2. **Does `neuriplo-tasks::vision-opencv` survive?** After this, the app is its
    only consumer. Keeping it costs nothing and helps external adopters; removing
    it deletes the last `cv::Mat` interop in the family. Not urgent either way.

--- a/specs/2026-08-31-opencv-free-app/requirements.md
+++ b/specs/2026-08-31-opencv-free-app/requirements.md
@@ -144,18 +144,57 @@ requires this work — it is entirely an application-layer concern.
 
 1. **What replaces the live preview window?** `cv::imshow` / `cv::waitKey` in
    the two video loops is the only OpenCV use with no in-family replacement.
-   Three options, and the maintainer picks:
+   **Undecided.** Measured evidence, installed-size delta with
+   `--no-install-recommends`, taken on both `ubuntu:24.04` and
+   `nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04` (the TensorRT base) — the two
+   bases agree to within 1 MB, so the CUDA image carries no GL of its own and
+   there is no free lunch there:
 
-   - **(a) Drop it.** Annotated frames or a video file are written instead.
-     No new dependency, and it is what *"No GUI, no server, no daemon. This is a
-     CLI."* already says. Loses live monitoring; a CLI contract change.
-   - **(b) SDL2 behind `NEURIPLO_INFER_WITH_DISPLAY`, default OFF.** Preserves
-     the feature and matches what `videocapture` v0.4.0 did. Requires explicit
-     maintainer approval for a new runtime dependency, and sits in tension with
-     the no-GUI rule.
-   - **(c) Keep OpenCV as an optional display-only component.** Headless images
-     (the whole point) drop it; anyone wanting a preview installs it. Cheapest,
-     but leaves an OpenCV code path in the app forever.
+   | Option | Added | What dominates |
+   |---|---:|---|
+   | Raw X11 (`libx11-6` + `libxext6`) | **+4 MB** | nothing — no GL at all |
+   | sokol / GLFW X11 libs, without GL | +4 MB | `X11`, `Xi`, `Xcursor` |
+   | GLFW (`libglfw3`) | +225 MB | the GL stack; GLFW itself ≈ 0 |
+   | sokol with `SOKOL_GLCORE` (GLX) | +225 MB | `libgl1` |
+   | sokol with `SOKOL_GLES3` (EGL) | +224 MB | `libegl1` + `libgles2` |
+   | `libgl1` alone, for reference | +225 MB | `libllvm20` 137 MB + `mesa-libgallium` 42 MB |
+   | SDL2 (`libsdl2-2.0-0`) | +237 MB | the same GL stack; SDL2 itself is 1.9 MB |
+   | OpenCV highgui | +433 MB | Qt5 — Ubuntu builds highgui against Qt5, not GTK |
+   | `libopencv-dev`, installed today | +1088 MB | the full OpenCV stack |
+
+   The shape of the table matters more than any single row. **Every GL-based
+   option costs the same ~225 MB**, because Mesa's software GL pulls
+   `libllvm20`. SDL2 is not lighter because SDL2 is small — it is 1.9 MB; 225 of
+   its 237 MB is a GL stack that a window blitting a BGR buffer never uses.
+   The only option that escapes the GL tax is the one that never asks for a
+   context.
+
+   Candidates:
+
+   - **Drop the preview.** Write annotated frames or a video file instead. No
+     dependency at all, and it is what *"No GUI, no server, no daemon. This is a
+     CLI."* in `specs/tech-stack.md` already says. Loses live monitoring; a CLI
+     contract change.
+   - **Raw X11 `XShmPutImage`.** +4 MB, ~60x lighter than SDL2's closure.
+     Create a window, blit a BGRA buffer, read one keypress. ~150 lines,
+     X11-only (works under XWayland). Cheapest by two orders of magnitude and
+     the only option whose cost is proportional to the feature.
+   - **SDL2.** +237 MB. Most batteries included — `SDL_UpdateTexture` +
+     `SDL_RenderCopy`, window and event loop handled — and the precedent
+     `videocapture` v0.4.0 set. Needs approval as a new runtime dependency.
+   - **sokol (`sokol_app` + `sokol_gfx`).** Rejected on evaluation, recorded so
+     it is not revisited from scratch. Attractive because it is a vendored
+     single header under a permissive license, adding no package and fitting the
+     pattern stb and the Hershey data already fit. But three things count
+     against it here: it needs a GL context, so the runtime cost is GLFW's
+     +225 MB and not zero; its Linux window and GL code is, by its own header,
+     *"taken from GLFW"*, so it is GLFW-as-a-header rather than something
+     lighter; and `sokol_app` is an application wrapper that **provides the
+     entry point and drives the program through `init_cb` / `frame_cb`**, which
+     inverts control away from a CLI that owns its own frame loop. Showing a
+     frame also means a texture upload and a fullscreen quad, more code than
+     SDL2's blit and far more than X11's. It is the GL cost of GLFW, more code
+     than SDL2, plus a vendored header to maintain.
 
    Everything else in this packet is independent of this answer, so the other
    groups can proceed while it is open.

--- a/specs/2026-08-31-opencv-free-app/validation.md
+++ b/specs/2026-08-31-opencv-free-app/validation.md
@@ -19,7 +19,16 @@ secondary to that one.
       developer machine proves nothing, because OpenCV is installed there and
       a stray `find_package` would silently succeed.
 - [ ] `ldd` on the built binary lists **no `libopencv_*`** for
-      `ONNX_RUNTIME`, `TENSORRT`, `LIBTORCH`, and KServe-only builds.
+      `ONNX_RUNTIME`, `TENSORRT`, `LIBTORCH`, and KServe-only builds — and no
+      `libSDL2` unless `NEURIPLO_INFER_WITH_DISPLAY=ON`.
+- [ ] A `NEURIPLO_INFER_WITH_DISPLAY=ON` build opens a window and ends on `q`
+      or Esc, on a real video, with the overlay drawn — the feature this
+      exception was granted for actually works.
+- [ ] The **same** `NEURIPLO_INFER_WITH_DISPLAY=ON` binary, run with `DISPLAY`
+      unset, processes the whole video to the end without a window and without
+      failing — `env -u DISPLAY ./neuriplo-infer --source <video> …`. A display
+      build that dies on a headless host is the predictable way this flag
+      becomes a support burden.
 - [ ] `ldd` on an `OPENCV_DNN` build **does** list OpenCV, reached only through
       `neuriplo` — confirming the dependency moved rather than vanished.
 - [ ] `grep -rn "cv::\|opencv2" app/` returns nothing outside whatever the
@@ -88,8 +97,15 @@ secondary to that one.
 - [ ] Nothing in *Out of Scope* was implemented anyway — in particular, no
       rendering *policy* changed: no new colours, no re-laid-out labels, no
       "improved" skeleton.
-- [ ] Open Question 1 (the display decision) was answered by the maintainer and
-      the answer is recorded in `requirements.md`, not inferred from the code.
+- [ ] **No headless image gained SDL2.** For every `Dockerfile` built without
+      `NEURIPLO_INFER_WITH_DISPLAY`, the measured image-size delta versus today
+      is negative, and neither `libsdl2` nor its GL stack (`libgl1`,
+      `mesa-libgallium`, `libllvm20`) appears in `dpkg -l`. SDL2's closure is
+      +237 MB; leaking it into a serving container would cancel most of this
+      feature's benefit while every build still looked correct.
+- [ ] A default build does **not** call `find_package(SDL2)` — grep the
+      configure log. An optional dependency that is always discovered is a
+      required one with extra steps.
 - [ ] `neuriplo-tasks` is released and pinned to a concrete `vX.Y.Z` tag in
       `versions.env` before this branch is released
       (`scripts/validate_release_pins.sh` passes).

--- a/specs/2026-08-31-opencv-free-app/validation.md
+++ b/specs/2026-08-31-opencv-free-app/validation.md
@@ -1,0 +1,101 @@
+# Feature Validation — OpenCV-free application layer
+
+Written before implementation, so the criteria cannot be fitted to whatever gets
+built. Execute from this file at Group 8 — do not summarize it from memory.
+
+The central claim is falsifiable and must be tested as such: **the application
+builds and runs on a machine with no OpenCV installed.** Every other check is
+secondary to that one.
+
+## The decisive check
+
+- [ ] On a container with **no OpenCV package present at all**, a non-OpenCV
+      backend configures, builds, and runs:
+      ```bash
+      docker build -f docker/Dockerfile.onnxruntime -t neuriplo-infer:nocv .
+      docker run --rm neuriplo-infer:nocv --capabilities   # must succeed
+      ```
+      This is the only check that cannot pass by accident. A build on a
+      developer machine proves nothing, because OpenCV is installed there and
+      a stray `find_package` would silently succeed.
+- [ ] `ldd` on the built binary lists **no `libopencv_*`** for
+      `ONNX_RUNTIME`, `TENSORRT`, `LIBTORCH`, and KServe-only builds.
+- [ ] `ldd` on an `OPENCV_DNN` build **does** list OpenCV, reached only through
+      `neuriplo` — confirming the dependency moved rather than vanished.
+- [ ] `grep -rn "cv::\|opencv2" app/` returns nothing outside whatever the
+      display decision (Group 6) deliberately keeps.
+
+## Automated
+
+- [ ] Default build configures and builds:
+      `cmake -S . -B build -DDEFAULT_BACKEND=OPENCV_DNN -DCMAKE_BUILD_TYPE=Release && cmake --build build`
+- [ ] Test build and full suite pass:
+      `cmake -S . -B build-test -DDEFAULT_BACKEND=OPENCV_DNN -DENABLE_APP_TESTS=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build-test && ctest --test-dir build-test --output-on-failure`
+- [ ] `ctest` is run **serially as well as in parallel**. Six tests currently
+      fail only under `-j4` because they share `data/output/` writes; that
+      pre-existing flakiness must not be mistaken for a regression from this
+      work, nor hide one.
+- [ ] `neuriplo-tasks` passes in **both** configurations — `build-ocv` (which
+      carries the differential render tests) and `build-no-ocv` (which proves
+      the drawing layer itself needs no OpenCV).
+- [ ] Differential render tests: for `line`, `rectangle` (stroked and filled),
+      `circle`, `polyline` (open and closed), `blend`, `fillMasked`, and
+      `applyColormap(Turbo)`, `vision::draw` agrees with OpenCV to
+      **|Δ| ≤ 8 per channel on ≥ 99% of pixels** for anti-aliased strokes and
+      **exactly** for un-anti-aliased fills.
+- [ ] `measureText` agrees with `cv::getTextSize` to **≤ 1 px** in width,
+      height, and baseline for the SIMPLEX and DUPLEX fonts at scales 0.8 and
+      1.0 with thickness 2 — the values `ResultRenderer` and `utils::draw_label`
+      actually use — across ASCII 32–126 and a set of representative labels.
+- [ ] `--help` output is **byte-identical** before and after the CLI parser
+      replacement (Group 5). Capture it on `develop` first.
+- [ ] `pre-commit run --all-files` (clang-format, cppcheck) is clean.
+- [ ] `python3 scripts/sync_supported_model_types.py --check` passes.
+- [ ] `capabilities_cli_contract` and `capabilities_schema_contract` pass, with
+      **no `schema_version` bump** — this feature must not touch the published
+      contract.
+- [ ] Build variants still configure: KServe-only
+      (`-DNEURIPLO_INFER_ENABLE_LOCAL_BACKENDS=OFF`), local-only
+      (`-DNEURIPLO_INFER_ENABLE_KSERVE=OFF`), `-DNEURIPLO_INFER_ENABLE_GRPC=OFF`,
+      `-DWERROR=ON`, and `-DUSE_FFMPEG=ON`.
+
+## Manual
+
+- [ ] **Visual regression, one image per task type.** For detection, open-vocab
+      detection, classification, video classification, instance segmentation
+      (mask path *and* polygon path), pose, depth, and optical flow: run the same
+      model on the same input on `develop` and on this branch, save both
+      outputs, and compare them side by side. Record the pairs. Boxes,
+      skeletons, masks, colormaps, and labels must be in the same places, the
+      same colours, and the same thicknesses — the mask colour draw uses
+      `std::rand()` and will differ in hue, which is expected and is the only
+      accepted difference.
+- [ ] **Label text is not clipped** on a long class name and a short one, at
+      an image edge and at the top-left corner, where `draw_label` clamps.
+      This is the failure mode a wrong `measureText` produces, and it does not
+      show up in a pixel diff of a short label.
+- [ ] The primary invocation behaves as `requirements.md` specifies — record the
+      exact command and observed output.
+- [ ] Invalid, empty, and unsupported-combination inputs still fail fast with an
+      error naming the flag and the way out.
+- [ ] `bash docker_run_inference_e2e_example.sh --preset <preset> --dry-run` runs.
+- [ ] Image size delta recorded for each Dockerfile touched, before and after.
+- [ ] Every hyperlink added to docs resolves.
+
+## Definition of Done
+
+- [ ] Every requirement is implemented or explicitly deferred in `requirements.md`.
+- [ ] Nothing in *Out of Scope* was implemented anyway — in particular, no
+      rendering *policy* changed: no new colours, no re-laid-out labels, no
+      "improved" skeleton.
+- [ ] Open Question 1 (the display decision) was answered by the maintainer and
+      the answer is recorded in `requirements.md`, not inferred from the code.
+- [ ] `neuriplo-tasks` is released and pinned to a concrete `vX.Y.Z` tag in
+      `versions.env` before this branch is released
+      (`scripts/validate_release_pins.sh` passes).
+- [ ] `specs/tech-stack.md` no longer claims OpenCV is a system dependency.
+- [ ] Deviations from this file are recorded here, honestly, with what was run
+      instead.
+- [ ] `CHANGELOG.md` describes the user-visible change — including the display
+      change, which is a CLI contract change.
+- [ ] Spec, code, changelog, and roadmap tell the same story in one branch.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -80,6 +80,25 @@ is therefore only as fresh as the last manual run.
 
 ---
 
+## Phase 6 — OpenCV-free application layer · not started
+
+`neuriplo` confines OpenCV to its `OPENCV_DNN` backend, `neuriplo-tasks` makes it
+an optional adapter (default off), and `videocapture` v0.4.0 took `cv::Mat` out
+of its frame API. This repo is the last holdout: `find_package(OpenCV REQUIRED)`
+is unconditional, so a TensorRT or KServe-only build still needs OpenCV that no
+sibling asked for. The blocker is rendering — ~70 of the ~140 `cv::` uses in
+`app/` draw overlays, and nothing in the family draws.
+
+Packet: [`2026-08-31-opencv-free-app/`](2026-08-31-opencv-free-app/requirements.md).
+
+- Done when: a non-`OPENCV_DNN` image builds and runs with no OpenCV package
+  installed, `ldd` on its binary lists no `libopencv_*`, and the rendered output
+  is unchanged for every task type.
+- Blocked on: a maintainer decision about the live preview window
+  (`cv::imshow`), which has no in-family replacement — see Open Question 1.
+
+---
+
 ## Candidates — not scheduled
 
 Real, observed, small enough not to need a packet until someone picks one up:

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -94,8 +94,9 @@ Packet: [`2026-08-31-opencv-free-app/`](2026-08-31-opencv-free-app/requirements.
 - Done when: a non-`OPENCV_DNN` image builds and runs with no OpenCV package
   installed, `ldd` on its binary lists no `libopencv_*`, and the rendered output
   is unchanged for every task type.
-- Blocked on: a maintainer decision about the live preview window
-  (`cv::imshow`), which has no in-family replacement — see Open Question 1.
+- The live preview survives as SDL2 behind `NEURIPLO_INFER_WITH_DISPLAY`,
+  default OFF — an approved, bounded exception to the no-new-dependency rule,
+  so no headless image pays for it.
 
 ---
 

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -104,6 +104,10 @@ Packet: [`2026-08-31-opencv-free-app/`](2026-08-31-opencv-free-app/requirements.
 
 Real, observed, small enough not to need a packet until someone picks one up:
 
+- Consume the video-writer sink once `videocapture` ships it, so annotated
+  output can be a file rather than a directory of stills. Costs nothing extra in
+  an `-DUSE_FFMPEG=ON` build, since the codecs are already linked for capture.
+  Blocked on that sibling release; not this repo's work to start.
 - `versions.env` has accumulated a duplicated pin-comment block on every release;
   `scripts/cut_release.sh` appends instead of replacing it.
 - FP16/BF16 over gRPC works only with raw tensor contents; the `KSERVE_BINARY=0`


### PR DESCRIPTION
## Summary

- add requirements, implementation plan, and validation contract for removing the application-layer OpenCV dependency
- retain preview support through optional SDL2 behind `NEURIPLO_INFER_WITH_DISPLAY`, default OFF
- place framework-neutral raster primitives in neuriplo-tasks while keeping rendering policy in neuriplo-infer
- keep video writing out of scope until videocapture provides the sink API
- add the phase to the project roadmap

## Key acceptance boundaries

- non-OpenCV backends build and run without OpenCV installed or linked
- rendered output remains visually equivalent across every task type
- headless builds do not discover or package SDL2 or its GL dependency closure
- a display-enabled binary degrades cleanly when no display server is available
- implementation remains phased so every intermediate commit builds

## Validation

- documentation-only diff confirmed
- all relative hyperlinks resolve
- absolute GitHub hyperlink is reachable
- `git diff --check origin/develop...HEAD` passed

No implementation is included in this PR.